### PR TITLE
chore: Add use client directive to components

### DIFF
--- a/src/app/aboutus/page.tsx
+++ b/src/app/aboutus/page.tsx
@@ -1,3 +1,4 @@
+'use client'
 import React from 'react'
 
 const Aboutus = () => {
@@ -7,4 +8,3 @@ const Aboutus = () => {
 }
 
 export default Aboutus
-

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+'use client'
 import "@patternfly/patternfly/patternfly.css";
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+'use client'
 import "@patternfly/react-core/dist/styles/base.css";
 
 import { Button } from "@patternfly/react-core";


### PR DESCRIPTION
### Context
It seems that `next.js` is trying to render components on the server side but `@patternfly` is not yet compatible.

### Workaround
From [the docs](https://nextjs.org/docs/app/building-your-application/rendering/client-components), we can mark components to be rendered on the client side.