### PR TITLE
fix: remove reference to kaoto-next styles

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import "@patternfly/patternfly/patternfly.css";
-import "@kaoto-next/ui/style.css";
 
 import Script from 'next/script';
 


### PR DESCRIPTION
This fixes an issue with the build once you pull in the latest changes from `@kaoto-next/ui`.