### PR TITLE
chore: lock engine, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,21 @@
 This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
 
+## Requirements
+- [NodeJS](https://nodejs.org/en) (v18.x or higher)
+- [npm](https://www.npmjs.com/) (v3.x or higher)
+
 ## Getting Started
 
-First, run the development server:
+Install dependencies:
+
+```bash
+npm install
+```
+
+Run the development server:
 
 ```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
@@ -26,9 +32,3 @@ To learn more about Next.js, take a look at the following resources:
 - [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "sco-ui-next",
   "version": "0.1.0",
+  "repository": "git@github.com:sco1237896/sco-ui-next.git",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -36,6 +37,10 @@
     "sass": "^1.67.0",
     "storybook": "^7.4.5"
   },
+  "engines": {
+    "node": "18.x"
+  },
+  "packageManager": "npm@9.8.1",
   "resolutions": {
     "@types/react": "18.2.22",
     "react": "18.2.0",


### PR DESCRIPTION
## Description
The purpose of this PR is to lock the version of Node.js and npm we are using across the team. The `README.md` is also updated to include requirements and to remove unnecessary info.

**NOTE:** If you do not have Node.js `v18.x` you will get an error when building. It's recommended to use [nvm](https://github.com/nvm-sh/nvm) to manage Node.js versions.