### PR TITLE
chore: add code formatting with prettier

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,5 @@
 {
-  "extends": [
-    "next",
-    "next/core-web-vitals",
-    "eslint:recommended"
-  ],
+  "extends": ["next", "next/core-web-vitals", "eslint:recommended"],
   "rules": {
     "@next/next/no-before-interactive-script-outside-document": "off",
     "no-unused-vars": [1, { "args": "after-used", "argsIgnorePattern": "^_" }]

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,7 @@
     "eslint:recommended"
   ],
   "rules": {
-    "@next/next/no-before-interactive-script-outside-document": "off"
+    "@next/next/no-before-interactive-script-outside-document": "off",
+    "no-unused-vars": [1, { "args": "after-used", "argsIgnorePattern": "^_" }]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,9 @@
 {
-  "extends": "next/core-web-vitals",
+  "extends": [
+    "next",
+    "next/core-web-vitals",
+    "eslint:recommended"
+  ],
   "rules": {
     "@next/next/no-before-interactive-script-outside-document": "off"
   }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+.next
+dist
+node_modules

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true
+}

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,26 +1,26 @@
-import type { StorybookConfig } from "@storybook/nextjs";
-import path from "path";
+import type { StorybookConfig } from '@storybook/nextjs';
+import path from 'path';
 
 const config: StorybookConfig = {
-  stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   addons: [
-    "@storybook/addon-links",
-    "@storybook/addon-essentials",
-    "@storybook/addon-onboarding",
-    "@storybook/addon-interactions",
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    '@storybook/addon-onboarding',
+    '@storybook/addon-interactions',
   ],
   framework: {
-    name: "@storybook/nextjs",
+    name: '@storybook/nextjs',
     options: {},
   },
   docs: {
-    autodocs: "tag",
+    autodocs: 'tag',
   },
   webpackFinal: async (config) => {
     if (config.resolve) {
       config.resolve.alias = {
         ...config.resolve.alias,
-        react: path.resolve('./node_modules/react')
+        react: path.resolve('./node_modules/react'),
       };
     }
     return config;

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -4,11 +4,11 @@ import '@patternfly/patternfly/utilities/Display/display.css';
 import '@patternfly/patternfly/utilities/Flex/flex.css';
 import '@patternfly/patternfly/utilities/Sizing/sizing.css';
 import '@patternfly/patternfly/utilities/Spacing/spacing.css';
-import type { Preview } from "@storybook/react";
+import type { Preview } from '@storybook/react';
 
 const preview: Preview = {
   parameters: {
-    actions: { argTypesRegex: "^on[A-Z].*" },
+    actions: { argTypesRegex: '^on[A-Z].*' },
     controls: {
       matchers: {
         color: /(background|color)$/i,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll": true,
+    "source.organizeImports": true
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
 
 ## Requirements
+
 - [NodeJS](https://nodejs.org/en) (v18.x or higher)
 - [npm](https://www.npmjs.com/) (v3.x or higher)
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,15 +1,15 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-   transpilePackages: [
-        '@patternfly/patternfly',
-        '@patternfly/react-core',
-        '@patternfly/react-icons',
-        '@patternfly/react-table',
-        '@patternfly/react-styles',
-        '@patternfly/react-tokens',
-        '@patternfly/react-log-viewer',
-        'next-auth',
-    ],
-}
+  transpilePackages: [
+    '@patternfly/patternfly',
+    '@patternfly/react-core',
+    '@patternfly/react-icons',
+    '@patternfly/react-table',
+    '@patternfly/react-styles',
+    '@patternfly/react-tokens',
+    '@patternfly/react-log-viewer',
+    'next-auth',
+  ],
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,8 +30,12 @@
         "eslint": "8.49.0",
         "eslint-config-next": "13.4.19",
         "next-transpile-modules": "^10.0.1",
+        "prettier": "^3.0.3",
         "sass": "^1.67.0",
         "storybook": "^7.4.5"
+      },
+      "engines": {
+        "node": "18.x"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4969,6 +4973,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@storybook/cli/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/@storybook/cli/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -5132,6 +5151,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/codemod/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@storybook/components": {
@@ -14432,15 +14466,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -21132,6 +21166,12 @@
             "brace-expansion": "^2.0.1"
           }
         },
+        "prettier": {
+          "version": "2.8.8",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+          "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+          "dev": true
+        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -21253,6 +21293,12 @@
             "@types/express": "^4.7.0",
             "file-system-cache": "2.3.0"
           }
+        },
+        "prettier": {
+          "version": "2.8.8",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+          "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+          "dev": true
         }
       }
     },
@@ -28368,9 +28414,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
       "dev": true
     },
     "pretty-error": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "prettier": "prettier --write .",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },
@@ -34,6 +35,7 @@
     "eslint": "8.49.0",
     "eslint-config-next": "13.4.19",
     "next-transpile-modules": "^10.0.1",
+    "prettier": "^3.0.3",
     "sass": "^1.67.0",
     "storybook": "^7.4.5"
   },

--- a/src/app/aboutus/page.tsx
+++ b/src/app/aboutus/page.tsx
@@ -1,6 +1,6 @@
-'use client'
+'use client';
 
-import React from "react";
+import React from 'react';
 
 const Aboutus = () => {
   return <div>Aboutus</div>;

--- a/src/app/connectors/create-flow/page.stories.tsx
+++ b/src/app/connectors/create-flow/page.stories.tsx
@@ -1,11 +1,11 @@
-import { Meta, StoryFn } from "@storybook/react";
+import { Meta, StoryFn } from '@storybook/react';
 import { ITile } from '@kaoto-next/ui';
-import CreateFlow from "./page";
+import CreateFlow from './page';
 
 export default {
-  title: "CreateFlow",
-  component: CreateFlow
-} as Meta<typeof CreateFlow>
+  title: 'CreateFlow',
+  component: CreateFlow,
+} as Meta<typeof CreateFlow>;
 
 const Template: StoryFn<typeof CreateFlow> = (args) => {
   console.log(args);
@@ -15,7 +15,7 @@ const Template: StoryFn<typeof CreateFlow> = (args) => {
 export const Default = Template.bind({});
 Default.args = {
   tiles: {
-    "Source Connector": [
+    'Source Connector': [
       {
         name: 'connector-type 1',
         description: 'This is the description for connector-type 1',
@@ -24,7 +24,7 @@ Default.args = {
         type: 'link',
         headerTags: ['headerTag1', 'headerTag2'],
         version: '1.0.0',
-        rawObject: 'Tile 1 raw object'
+        rawObject: 'Tile 1 raw object',
       },
       {
         name: 'connector-type 2',
@@ -34,10 +34,10 @@ Default.args = {
         type: 'link',
         headerTags: ['headerTag1', 'headerTag2'],
         version: '1.0.0',
-        rawObject: 'Tile 1 raw object'
-      }
+        rawObject: 'Tile 1 raw object',
+      },
     ],
-    "Sink Connector": [
+    'Sink Connector': [
       {
         name: 'connector-type 3',
         description: 'This is the description for connector-type 3',
@@ -46,9 +46,9 @@ Default.args = {
         type: 'link',
         headerTags: ['headerTag1', 'headerTag2'],
         version: '1.0.0',
-        rawObject: 'Tile 1 raw object'
-      }
-    ]
+        rawObject: 'Tile 1 raw object',
+      },
+    ],
   } as Record<string, ITile[]>,
   onTileClick: () => {
     alert('Tile clicked! Omg');

--- a/src/app/connectors/create-flow/page.tsx
+++ b/src/app/connectors/create-flow/page.tsx
@@ -1,23 +1,28 @@
-"use client";
-import { Catalog, ITile } from "@kaoto-next/ui";
-import { PageSection, Split, SplitItem, TextContent, Text, Title } from "@patternfly/react-core";
+'use client';
+import { Catalog, ITile } from '@kaoto-next/ui';
+import {
+  PageSection,
+  Split,
+  SplitItem,
+  TextContent,
+  Text,
+  Title,
+} from '@patternfly/react-core';
 
 export interface ICreateFlowPage {
   onTileClick: () => void;
-  tiles: Record<string, ITile[]>
+  tiles: Record<string, ITile[]>;
 }
 
 const CreateFlowPage = ({ onTileClick, tiles }: ICreateFlowPage) => {
   return (
     <>
-      <PageSection variant={"light"}>
+      <PageSection variant={'light'}>
         <Split>
           <SplitItem isFilled>
             <TextContent>
               <Title headingLevel="h1">Create Flow</Title>
-              <Text>
-                Lorem ipsum dolorum
-              </Text>
+              <Text>Lorem ipsum dolorum</Text>
             </TextContent>
           </SplitItem>
         </Split>

--- a/src/app/connectors/layout.tsx
+++ b/src/app/connectors/layout.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 import {
   Button,
   Masthead,
@@ -12,47 +12,47 @@ import {
   Toolbar,
   ToolbarContent,
   ToolbarGroup,
-  ToolbarItem
-} from "@patternfly/react-core";
-import { ReactNode } from "react";
-import Link from "next/link";
-import { CogIcon, QuestionCircleIcon } from "@patternfly/react-icons";
+  ToolbarItem,
+} from '@patternfly/react-core';
+import { ReactNode } from 'react';
+import Link from 'next/link';
+import { CogIcon, QuestionCircleIcon } from '@patternfly/react-icons';
 
 export default function PatternflyLayout({
-                                           children
-                                         }: {
+  children,
+}: {
   children: ReactNode;
 }) {
   return (
     <Page
       header={
-        <Masthead id="stack-masthead" display={{ default: "stack" }}>
+        <Masthead id="stack-masthead" display={{ default: 'stack' }}>
           <MastheadMain>
-            <Link href={"/"} className={"pf-v5-c-masthead_brand pf-v5-u-mx-xl"}>
+            <Link href={'/'} className={'pf-v5-c-masthead_brand pf-v5-u-mx-xl'}>
               Smart Connectors
             </Link>
             <Toolbar id="toolbar" isFullHeight isStatic>
               <ToolbarContent>
                 <ToolbarGroup
                   variant="icon-button-group"
-                  align={{ default: "alignRight" }}
-                  spacer={{ default: "spacerNone", md: "spacerMd" }}
+                  align={{ default: 'alignRight' }}
+                  spacer={{ default: 'spacerNone', md: 'spacerMd' }}
                 >
                   <ToolbarGroup
                     variant="icon-button-group"
-                    visibility={{ default: "hidden", lg: "visible" }}
+                    visibility={{ default: 'hidden', lg: 'visible' }}
                   >
                     <ToolbarItem>
                       <Button
                         aria-label="Settings"
-                        variant={"plain"}
+                        variant={'plain'}
                         icon={<CogIcon />}
                       />
                     </ToolbarItem>
                     <ToolbarItem>
                       <Button
                         aria-label="Help"
-                        variant={"plain"}
+                        variant={'plain'}
                         icon={<QuestionCircleIcon />}
                       />
                     </ToolbarItem>
@@ -68,7 +68,13 @@ export default function PatternflyLayout({
           <PageSidebarBody>
             <Nav aria-label="Nav">
               <NavList>
-                <NavItem id={"connectors"} to={"/connectors/create-flow"} itemId={0}>Connectors</NavItem>
+                <NavItem
+                  id={'connectors'}
+                  to={'/connectors/create-flow'}
+                  itemId={0}
+                >
+                  Connectors
+                </NavItem>
               </NavList>
             </Nav>
           </PageSidebarBody>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,21 +1,18 @@
-'use client'
+'use client';
 
-import "@patternfly/patternfly/patternfly.css";
+import '@patternfly/patternfly/patternfly.css';
+import '@kaoto-next/ui/style.css';
 
 import Script from 'next/script';
-import { ReactNode } from "react";
+import { ReactNode } from 'react';
 
-export default function RootLayout({
-  children,
-}: {
-  children: ReactNode;
-}) {
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body>
         {children}
 
-        <Script strategy='beforeInteractive' id={'patternfly-workaround'}>
+        <Script strategy="beforeInteractive" id={'patternfly-workaround'}>
           {/* Temporary workaround for @patternfly/react-topology using global */}
           {`window.global ||= window;`}
         </Script>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,11 +3,12 @@
 import "@patternfly/patternfly/patternfly.css";
 
 import Script from 'next/script';
+import { ReactNode } from "react";
 
 export default function RootLayout({
   children,
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
   return (
     <html lang="en">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
-'use client'
+'use client';
 
-import "@patternfly/react-core/dist/styles/base.css";
-import { Button } from "@patternfly/react-core";
+import '@patternfly/react-core/dist/styles/base.css';
+import { Button } from '@patternfly/react-core';
 
 export default function Home() {
   return (

--- a/src/app/playground/page.tsx
+++ b/src/app/playground/page.tsx
@@ -1,10 +1,9 @@
-'use client'
+'use client';
 import { Card, CardBody, CardTitle } from '@patternfly/react-core';
 import { Catalog, ITile } from '@kaoto-next/ui';
 import { useCallback } from 'react';
 
 export default function PlaygroundPage() {
-
   const tiles: Record<string, Array<ITile<string>>> = {
     Group1: [
       {
@@ -15,9 +14,9 @@ export default function PlaygroundPage() {
         type: 'link',
         headerTags: ['headerTag1', 'headerTag2'],
         version: '1.0.0',
-        rawObject: 'Tile 1 raw object'
-      }
-    ]
+        rawObject: 'Tile 1 raw object',
+      },
+    ],
   };
 
   const onTileClick = useCallback((tile: ITile<unknown>) => {
@@ -35,7 +34,6 @@ export default function PlaygroundPage() {
         </p>
 
         <Catalog tiles={tiles} onTileClick={onTileClick} />
-
       </CardBody>
     </Card>
   );

--- a/src/app/playground/page.tsx
+++ b/src/app/playground/page.tsx
@@ -39,4 +39,4 @@ export default function PlaygroundPage() {
       </CardBody>
     </Card>
   );
-};
+}

--- a/src/components/Catalog/Catalog.stories.tsx
+++ b/src/components/Catalog/Catalog.stories.tsx
@@ -1,9 +1,9 @@
 import { Catalog, ITile } from '@kaoto-next/ui';
-import { Meta, StoryFn } from "@storybook/react";
+import { Meta, StoryFn } from '@storybook/react';
 
 export default {
-    title: "Components/Catalog",
-    component: Catalog
+  title: 'Components/Catalog',
+  component: Catalog,
 } as Meta<typeof Catalog>;
 
 const Template: StoryFn<typeof Catalog> = (args) => {
@@ -14,7 +14,7 @@ const Template: StoryFn<typeof Catalog> = (args) => {
 export const Gallery = Template.bind({});
 Gallery.args = {
   tiles: {
-    "Source Connector": [
+    'Source Connector': [
       {
         name: 'connector-type 1',
         description: 'This is the description for connector-type 1',
@@ -23,7 +23,7 @@ Gallery.args = {
         type: 'link',
         headerTags: ['headerTag1', 'headerTag2'],
         version: '1.0.0',
-        rawObject: 'Tile 1 raw object'
+        rawObject: 'Tile 1 raw object',
       },
       {
         name: 'connector-type 2',
@@ -33,10 +33,10 @@ Gallery.args = {
         type: 'link',
         headerTags: ['headerTag1', 'headerTag2'],
         version: '1.0.0',
-        rawObject: 'Tile 1 raw object'
-      }
+        rawObject: 'Tile 1 raw object',
+      },
     ],
-    "Sink Connector": [
+    'Sink Connector': [
       {
         name: 'connector-type 3',
         description: 'This is the description for connector-type 3',
@@ -45,9 +45,9 @@ Gallery.args = {
         type: 'link',
         headerTags: ['headerTag1', 'headerTag2'],
         version: '1.0.0',
-        rawObject: 'Tile 1 raw object'
-      }
-    ]
+        rawObject: 'Tile 1 raw object',
+      },
+    ],
   } as Record<string, ITile[]>,
   onTileClick: () => {
     alert('Tile clicked! Omg');

--- a/src/components/Catalog/ExampleForm.stories.tsx
+++ b/src/components/Catalog/ExampleForm.stories.tsx
@@ -1,36 +1,51 @@
-import React, { useState } from "react";
-import { Meta, StoryFn } from "@storybook/react";
-import { ActionGroup, Button, Form, FormGroup, TextInput } from "@patternfly/react-core";
+import React, { useState } from 'react';
+import { Meta, StoryFn } from '@storybook/react';
+import {
+  ActionGroup,
+  Button,
+  Form,
+  FormGroup,
+  TextInput,
+} from '@patternfly/react-core';
 
 const FormComponent = ({ defaultState = false }) => {
   const [isSubmitted, setIsSubmitted] = useState(defaultState);
 
-  return (<Form>
-    <div>Has the form been submitted? <strong>{isSubmitted ? (<>🥳 Omg! Yes</>) : (<>🥲 Sadly, No</>)}</strong></div>
-    <FormGroup label={'Name'}>
-      <TextInput
-        isRequired
-        type="text"
-        id="name"
-        name="name"
-        aria-describedby="name-helper"
-        value={'something'}
-        onChange={() => {console.log('handle change')}}
-      />
-    </FormGroup>
-    <ActionGroup>
-      <Button variant="primary" onClick={() => setIsSubmitted(true)}>
-        Submit
-      </Button>
-      <Button variant="link" onClick={() => setIsSubmitted(false)}>Clear</Button>
-    </ActionGroup>
-  </Form>);
-}
+  return (
+    <Form>
+      <div>
+        Has the form been submitted?{' '}
+        <strong>{isSubmitted ? <>🥳 Omg! Yes</> : <>🥲 Sadly, No</>}</strong>
+      </div>
+      <FormGroup label={'Name'}>
+        <TextInput
+          isRequired
+          type="text"
+          id="name"
+          name="name"
+          aria-describedby="name-helper"
+          value={'something'}
+          onChange={() => {
+            console.log('handle change');
+          }}
+        />
+      </FormGroup>
+      <ActionGroup>
+        <Button variant="primary" onClick={() => setIsSubmitted(true)}>
+          Submit
+        </Button>
+        <Button variant="link" onClick={() => setIsSubmitted(false)}>
+          Clear
+        </Button>
+      </ActionGroup>
+    </Form>
+  );
+};
 
 export default {
-  title: "Components/Form",
-  component: FormComponent
-} as Meta<typeof FormComponent>
+  title: 'Components/Form',
+  component: FormComponent,
+} as Meta<typeof FormComponent>;
 
 const Template: StoryFn<typeof FormComponent> = (args) => {
   console.log(args);
@@ -42,5 +57,5 @@ Default.args = {};
 
 export const OverriddenWithArgs = Template.bind({});
 OverriddenWithArgs.args = {
-  defaultState: true
+  defaultState: true,
 };

--- a/src/components/Catalog/Form.stories.tsx
+++ b/src/components/Catalog/Form.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+// import React, { useState } from "react";
 import { Meta } from "@storybook/react";
 
 export default {
@@ -8,11 +8,11 @@ export default {
 export const Button = () => {
     // const [text, setText] = useState("hello");
 
-    function buttonHandler(event) {
-        // setText("Hola");
-        console.log("hello");
-
-    }
+    // function buttonHandler(event) {
+    //     // setText("Hola");
+    //     console.log("hello");
+    //
+    // }
     
     // return <div><button onClick={buttonHandler}>{text}</button></div>;
     return <div></div>;

--- a/src/components/Catalog/Form.stories.tsx
+++ b/src/components/Catalog/Form.stories.tsx
@@ -1,19 +1,19 @@
 // import React, { useState } from "react";
-import { Meta } from "@storybook/react";
+import { Meta } from '@storybook/react';
 
 export default {
-    title: "Form/Button"
+  title: 'Form/Button',
 } as Meta<typeof Button>;
 
 export const Button = () => {
-    // const [text, setText] = useState("hello");
+  // const [text, setText] = useState("hello");
 
-    // function buttonHandler(event) {
-    //     // setText("Hola");
-    //     console.log("hello");
-    //
-    // }
-    
-    // return <div><button onClick={buttonHandler}>{text}</button></div>;
-    return <div></div>;
-}
+  // function buttonHandler(event) {
+  //     // setText("Hola");
+  //     console.log("hello");
+  //
+  // }
+
+  // return <div><button onClick={buttonHandler}>{text}</button></div>;
+  return <div></div>;
+};

--- a/src/stories/Configure.mdx
+++ b/src/stories/Configure.mdx
@@ -1,7 +1,5 @@
-import { Meta } from "@storybook/blocks";
+import { Meta } from '@storybook/blocks';
 
 <Meta title="Smart Connectors" />
 
-<div>
-  Hello World
-</div>
+<div>Hello World</div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
     ],
     "paths": {
       "@/*": ["./src/*"],
-      "react": [ "./node_modules/@types/react" ]
+      "react": ["./node_modules/@types/react"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## Description
This PR adds code formatting with [Prettier](https://prettier.io/) for consistency and to make code reviews easier down the line. You'll now be able to run `npm run prettier` and have it automatically format your code.

Implements [SCO-65](https://issues.redhat.com/browse/SCO-65).

## Changes
- Add prettier and configuration
- Reformat existing code base with prettier
- Add IDE-specific overrides for code formatting
- Update `README.md` with instructions