### PR TITLE
fix(ci): fix typo in chromatic workflow

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -24,4 +24,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           projectToken: chpt_dbf5c97211fca0a
-          buildScriptName: build:storybook
+          buildScriptName: build-storybook


### PR DESCRIPTION
## Description
This PR fixes a typo in the GitHub actions workflow where we refer to the npm script as `build:storybook` but it should actually be `build-storybook`.